### PR TITLE
Avoid hardly debugable PHP.exe crashes

### DIFF
--- a/ibase_query.c
+++ b/ibase_query.c
@@ -1854,6 +1854,10 @@ PHP_FUNCTION(ibase_execute)
 				_php_ibase_error();
 				break;
 			}
+			if (ib_query->result_res->gc.refcount > 1) {
+				php_printf("ERROR: Query result of '%s' was not released before executing the same query again!\n", ib_query->query);
+				php_error_docref(NULL, E_ERROR, "Query result of '%s' was not released before executing the same query again!", ib_query->query); /* throw exception*/
+			}
 			zend_list_delete(ib_query->result_res);
 			ib_query->result_res = NULL;
 		}

--- a/ibase_query.c
+++ b/ibase_query.c
@@ -1854,10 +1854,6 @@ PHP_FUNCTION(ibase_execute)
 				_php_ibase_error();
 				break;
 			}
-			if (ib_query->result_res->gc.refcount > 1) {
-				php_printf("ERROR: Query result of '%s' was not released before executing the same query again!\n", ib_query->query);
-				php_error_docref(NULL, E_ERROR, "Query result of '%s' was not released before executing the same query again!", ib_query->query); /* throw exception*/
-			}
 			zend_list_delete(ib_query->result_res);
 			ib_query->result_res = NULL;
 		}


### PR DESCRIPTION
The current code causes hardly debugable PHP.exe crashes in case when PHP developer does not release query or results in proper order.
This is just minimal fix of just one such scenario.
Architectural fix would be better of course i.e. defining supported scenarios and throwing regular PHP exception instead of crashing PHP.exe in unsuported cases.

THE FIX:
Avoids memory overwrites of released query or result (the memory already allocated by somebody else) or in case of more cursors opened for one query at the time of query destruction.