### PR TITLE
Fix arg info

### DIFF
--- a/interbase.c
+++ b/interbase.c
@@ -105,7 +105,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_ibase_commit_ret, 0, 0, 0)
 	ZEND_ARG_INFO(0, link_identifier)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_ibase_rollback_ret, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ibase_rollback_ret, 0, 0, 0)
 	ZEND_ARG_INFO(0, link_identifier)
 ZEND_END_ARG_INFO()
 

--- a/interbase.c
+++ b/interbase.c
@@ -101,7 +101,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_ibase_rollback, 0, 0, 0)
 	ZEND_ARG_INFO(0, link_identifier)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_ibase_commit_ret, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ibase_commit_ret, 0, 0, 0)
 	ZEND_ARG_INFO(0, link_identifier)
 ZEND_END_ARG_INFO()
 

--- a/interbase.c
+++ b/interbase.c
@@ -93,7 +93,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_ibase_trans, 0, 0, 0)
 	ZEND_ARG_INFO(0, link_identifier)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_ibase_commit, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ibase_commit, 0, 0, 0)
 	ZEND_ARG_INFO(0, link_identifier)
 ZEND_END_ARG_INFO()
 

--- a/interbase.c
+++ b/interbase.c
@@ -97,7 +97,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_ibase_commit, 0, 0, 0)
 	ZEND_ARG_INFO(0, link_identifier)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_ibase_rollback, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_ibase_rollback, 0, 0, 0)
 	ZEND_ARG_INFO(0, link_identifier)
 ZEND_END_ARG_INFO()
 

--- a/tests/ibase_commit_001.phpt
+++ b/tests/ibase_commit_001.phpt
@@ -1,0 +1,18 @@
+--TEST--
+ibase_commit(): Make sure the method can be invoked with zero arguments
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--FILE--
+<?php
+
+require("interbase.inc");
+
+ibase_connect($test_base);
+
+ibase_query('INSERT INTO test1 VALUES (100, 2)');
+
+var_dump(ibase_commit());
+
+?>
+--EXPECTF--
+bool(true)

--- a/tests/ibase_commit_ret_001.phpt
+++ b/tests/ibase_commit_ret_001.phpt
@@ -1,0 +1,18 @@
+--TEST--
+ibase_commit_ret(): Make sure the method can be invoked with zero arguments
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--FILE--
+<?php
+
+require("interbase.inc");
+
+ibase_connect($test_base);
+
+ibase_query('INSERT INTO test1 VALUES (100, 2)');
+
+var_dump(ibase_commit_ret());
+
+?>
+--EXPECTF--
+bool(true)

--- a/tests/ibase_rollback_002.phpt
+++ b/tests/ibase_rollback_002.phpt
@@ -1,0 +1,18 @@
+--TEST--
+ibase_rollback(): Make sure the method can be invoked with zero arguments
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--FILE--
+<?php
+
+require("interbase.inc");
+
+ibase_connect($test_base);
+
+ibase_query('INSERT INTO test1 VALUES (100, 2)');
+
+var_dump(ibase_rollback());
+
+?>
+--EXPECTF--
+bool(true)

--- a/tests/ibase_rollback_ret_001.phpt
+++ b/tests/ibase_rollback_ret_001.phpt
@@ -1,0 +1,18 @@
+--TEST--
+ibase_rollback_ret(): Make sure the method can be invoked with zero arguments
+--SKIPIF--
+<?php include("skipif.inc"); ?>
+--FILE--
+<?php
+
+require("interbase.inc");
+
+ibase_connect($test_base);
+
+ibase_query('INSERT INTO test1 VALUES (100, 2)');
+
+var_dump(ibase_rollback_ret());
+
+?>
+--EXPECTF--
+bool(true)


### PR DESCRIPTION
When running a debug build of PHP, the engine verifies that the info supplied in the `ZEND_BEGIN_ARG_INFO_EX` macro is correct. The last parameter of the `ZEND_BEGIN_ARG_INFO_EX` macro is the number of required arguments.

For example, if we try to invoke `ibase_commit` with zero arguments, we get the following error message:
```
Fatal error: Arginfo / zpp mismatch during call of ibase_commit() in test.php on line 123
```

This PR fixes this problem for `ibase_commit`, `ibase_commit_ret`, `ibase_rollback`, and `ibase_rollback_ret`.