### PR TITLE
Fix memory leak of prepared queries

### DIFF
--- a/ibase_query.c
+++ b/ibase_query.c
@@ -1959,6 +1959,7 @@ PHP_FUNCTION(ibase_free_query)
 	}
 
 	zend_list_close(Z_RES_P(query_arg));
+	zend_list_delete(Z_RES_P(query_arg));
 	RETURN_TRUE;
 }
 /* }}} */


### PR DESCRIPTION
When a query is prepared with `ibase_prepare()` and then it is freed with `ibase_free_query()`, the associated `zend_resource` object is never freed, because the function `ibase_free_query()` does not decrease its ref count and it stays forever at 1 (after all the variables holding reference in php are destroyed).

I was also considering to use a following fix:
```
uint32_t refcount = GC_REFCOUNT(Z_RES_P(query_arg));
zend_list_close(Z_RES_P(query_arg));
if (refcount > 0) {
	zend_list_delete(Z_RES_P(query_arg));
}
```
This solution would avoid memory access violations in cases when the `refcount` is already 0 (because the `zend_resource` would get freed in `zend_list_close()`), but I would argue that this situation should never occurr and it could happen only if the internal reference created during `ibase_prepare()` was freed by some other parts of the code. But that is not correct and instead, it should be always freed only here.