### PR TITLE
Windows build script updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ tests/*.sh
 # coverage
 /coverage.info
 /reports
+win_build_scripts
+.vscode-win

--- a/build_scripts/README.md
+++ b/build_scripts/README.md
@@ -16,10 +16,8 @@ Make sure ``git`` is in you PATH
 2. Set up Firebird 32-bit and 64-bit installations or libraries.
 3. Set up PHP-SDK according to https://wiki.php.net/internals/windows/stepbystepbuild_sdk_2
 4. Clone php-firebird extension source somewhere.
-4. Copy these build scripts to C:\php-sdk\
 5. Adjust php-fb-config.bat.
-
     ``Note: PFB_SOURCE_DIR should point one level up. For example
     PFB_SOURCE_DIR=D:\php-firebird\ then your source should reside in D:\php-firebird\php-firebird\
     ``
-6. Run ``php-fb-build-all.bat`` to build for all PHP versions or run ``php-fb-build.bat 7.4 vc15`` to build for particular version.
+6. cd into php-sdk and from there run ``<path_to>\php-fb-build-all.bat`` to build for all PHP versions or run ``php-fb-build.bat 7.4 vc15`` to build for particular version.

--- a/build_scripts/php-fb-build-all.bat
+++ b/build_scripts/php-fb-build-all.bat
@@ -1,10 +1,10 @@
 @echo off
 
-call php-fb-build.bat 7.3 vc15 || exit /B %ERRORLEVEL%
-call php-fb-build.bat 7.4 vc15 || exit /B %ERRORLEVEL%
-call php-fb-build.bat 8.0 vs16 || exit /B %ERRORLEVEL%
-call php-fb-build.bat 8.1 vs16 || exit /B %ERRORLEVEL%
-call php-fb-build.bat 8.2 vs16 || exit /B %ERRORLEVEL%
-call php-fb-build.bat 8.3 vs16 || exit /B %ERRORLEVEL%
-call php-fb-build.bat 8.4 vs17 || exit /B %ERRORLEVEL%
-call php-fb-build.bat master vs17 || exit /B %ERRORLEVEL%
+call %~dp0php-fb-build.bat php-7.3.33 vc15 || exit %ERRORLEVEL%
+call %~dp0php-fb-build.bat php-7.4.13 vc15 || exit %ERRORLEVEL%
+call %~dp0php-fb-build.bat php-8.0.30 vs16 || exit %ERRORLEVEL%
+call %~dp0php-fb-build.bat php-8.1.33 vs16 || exit %ERRORLEVEL%
+call %~dp0php-fb-build.bat php-8.2.29 vs16 || exit %ERRORLEVEL%
+call %~dp0php-fb-build.bat php-8.3.26 vs16 || exit %ERRORLEVEL%
+call %~dp0php-fb-build.bat php-8.4.13 vs17 || exit %ERRORLEVEL%
+call %~dp0php-fb-build.bat php-8.5.0RC2 vs17 || exit %ERRORLEVEL%

--- a/build_scripts/php-fb-build.bat
+++ b/build_scripts/php-fb-build.bat
@@ -1,7 +1,7 @@
 @echo off
 
 @REM config  ======================================================================================
-call php-fb-config.bat
+call %~dp0php-fb-config.bat
 
 goto :MAIN
 
@@ -15,69 +15,114 @@ goto :MAIN
     echo ---------------------------------------------------------------------
 exit /B
 
+@REM usage  =======================================================================================
 :usage
-    call :log "Usage: %~nx0 php_vers cpp_vers"
+    call :log "Usage: %~nx0 php_tag cpp_vers"
+exit /B
+
+@REM validate_build ===============================================================================
+@REM validate_build <path_to_php_exe>:string <arch>:string <ts>:int
+:validate_build
+setlocal disabledelayedexpansion
+set vb_php=%~1
+set vb_arch=%~2
+set vb_ts=%~3
+
+set vb_check_code=^
+if(!extension_loaded('interbase')){ print \"Extension not loaded\n\"; exit(1); }^
+if('php-'.PHP_VERSION != '%pfb_php_tag%'){ printf(\"Version mismatch: expected '%pfb_php_tag%', but got '%%s' \n\", 'php-'.PHP_VERSION); exit(1); }^
+if((int)ZEND_THREAD_SAFE != %vb_ts%){ printf(\"Thread Safety mismatch: expected %vb_ts%, but got %%d \n\", ZEND_THREAD_SAFE); exit(1); }^
+if((PHP_INT_SIZE == 8 ? 'x64' : 'x86') != '%vb_arch%'){ printf(\"Architecture mismatch: expected '%vb_arch%', but got '%%s' \n\", (PHP_INT_SIZE == 8 ? 'x64' : 'x86')); exit(1); }
+
+if "%vb_arch%" == "x86" (
+    set vb_libs=%PFB_FB32_DIR%
+) else (
+    set vb_libs=%PFB_FB64_DIR%
+)
+
+call :log "Validating %pfb_php_tag% %vb_arch% Thread Safety %vb_ts%"
+
+set vb_cmd=cmd /c set "PATH=%vb_libs%;%PATH%" %php_exe% -dextension=.\php_interbase.dll -r "%vb_check_code%"
+%vb_cmd% || exit /B 1
+
+echo Validated OK
+echo ---------------------------------------------------------------------
+
 exit /B
 
 :MAIN
-set pfb_php_vers=%1
+
+set pfb_php_tag=%1
 set pfb_cpp_vers=%2
 
-if [%pfb_php_vers%] == [] (
+if "%pfb_php_tag%" == "" (
     call :usage
-    echo pfb_php_vers varible not set
+    echo pfb_php_tag varible not set
     exit 1
 )
 
-if [%pfb_cpp_vers%] == [] (
+if "%pfb_cpp_vers%" == "" (
     call :usage
     echo pfb_cpp_vers varible not set
     exit 1
 )
 
+@REM Convert php-8.4.13 -> 8.4
+for /f "tokens=2,3 delims=-." %%a in ("%pfb_php_tag%") do set pfb_php_vers=%%a.%%b
+
+if "%pfb_php_vers%" == "" (
+    echo BUG: pfb_php_vers should be set at this point
+    exit 1
+)
+
 set pfb_build_root=php%pfb_php_vers%\%pfb_cpp_vers%\
 
-(for %%a in (x86 x64) do (
-    @REM check out or pull PHP version of interest
-    if exist %pfb_build_root%\%%a\php-src\.git\ (
-        call :log "Checking out PHP-%pfb_php_vers% %%a"
-        git -C %pfb_build_root%\%%a\php-src pull || goto :error
-    ) else (
-        call :log "Cloning PHP-%pfb_php_vers% %%a"
-        call phpsdk-%pfb_cpp_vers%-%%a.bat -t php-fb-sdk-init.bat || goto :error
+(for %%a in (x64 x86) do (
+    set pfb_arch=%%a
+
+    if not exist "%pfb_build_root%\%%a\php-src\.git\" (
+        call :log "Cloning %pfb_php_tag% %%a"
+        call phpsdk-%pfb_cpp_vers%-%%a.bat -t %~dp0php-fb-sdk-init.bat || goto :error
     )
 
-    if %%a EQU x86 ( set pfb_x86=1 ) else ( set pfb_x86=0 )
+    if "%%a" == "x86" (
+        set php_exe_arch=%pfb_build_root%%%a\php-src\
+    ) else (
+        set php_exe_arch=%pfb_build_root%%%a\php-src\x64\
+    )
 
-    (for %%n in (0 1) do (
-        set pfb_nts=%%n
-        call phpsdk-%pfb_cpp_vers%-%%a.bat -t php-fb-sdk-build.bat || goto :error
+    setlocal enabledelayedexpansion
+    (for %%t in (0 1) do (
+        set pfb_ts=%%t
+        if "%%t" equ "1" (
+            set php_exe="!php_exe_arch!Release_TS\php.exe"
+        ) else (
+            set php_exe="!php_exe_arch!Release\php.exe"
+        )
+
+        if "!php_exe!" == "" (
+            echo BUG: php_exe should be set at this point
+            exit 1
+        )
+
+        call phpsdk-%pfb_cpp_vers%-%%a.bat -t %~dp0php-fb-sdk-build.bat || goto :error
+
+        call :validate_build !php_exe! !pfb_arch! !pfb_ts! || goto :error
     ))
 ))
 
-@REM check if ibase_connect() function exists in newly compiled extension
-set check_code="if(!function_exists('ibase_connect'))exit(1);"
-
-set TPATH=%PATH%
-set PATH=%FB64_DIR%;%TPATH%
-"%pfb_build_root%x64\php-src\x64\Release_TS\php.exe" -dextension=.\php_interbase.dll -r %check_code% || goto :error
-"%pfb_build_root%x64\php-src\x64\Release\php.exe" -dextension=.\php_interbase.dll -r %check_code% || goto :error
-set PATH=%FB32_DIR%;%TPATH%
-"%pfb_build_root%x86\php-src\Release_TS\php.exe" -dextension=.\php_interbase.dll -r %check_code% || goto :error
-"%pfb_build_root%x86\php-src\Release\php.exe" -dextension=.\php_interbase.dll -r %check_code% || goto :error
-set PATH=%TPATH%
-
-call :log "PHP %pfb_php_vers% build OK"
+echo.
+call :log "%pfb_php_tag% build OK"
 
 @REM copy compiled extension to target directory
-copy %pfb_build_root%x64\php-src\x64\Release_TS\php_interbase.dll %PFB_OUTPUT_DIR%php_interbase-%PFB_VERS%-%pfb_php_vers%-%pfb_cpp_vers%-x86_64.dll>nul
-copy %pfb_build_root%x64\php-src\x64\Release\php_interbase.dll %PFB_OUTPUT_DIR%php_interbase-%PFB_VERS%-%pfb_php_vers%-%pfb_cpp_vers%-nts-x86_64.dll>nul
-copy %pfb_build_root%x86\php-src\Release_TS\php_interbase.dll %PFB_OUTPUT_DIR%php_interbase-%PFB_VERS%-%pfb_php_vers%-%pfb_cpp_vers%.dll>nul
-copy %pfb_build_root%x86\php-src\Release\php_interbase.dll %PFB_OUTPUT_DIR%php_interbase-%PFB_VERS%-%pfb_php_vers%-%pfb_cpp_vers%-nts.dll>nul
+copy %pfb_build_root%x64\php-src\x64\Release_TS\php_interbase.dll %PFB_OUTPUT_DIR%php_interbase-%PFB_VERS%-%pfb_php_vers%-%pfb_cpp_vers%-x64.dll
+copy %pfb_build_root%x64\php-src\x64\Release\php_interbase.dll %PFB_OUTPUT_DIR%php_interbase-%PFB_VERS%-%pfb_php_vers%-%pfb_cpp_vers%-nts-x64.dll
+copy %pfb_build_root%x86\php-src\Release_TS\php_interbase.dll %PFB_OUTPUT_DIR%php_interbase-%PFB_VERS%-%pfb_php_vers%-%pfb_cpp_vers%.dll
+copy %pfb_build_root%x86\php-src\Release\php_interbase.dll %PFB_OUTPUT_DIR%php_interbase-%PFB_VERS%-%pfb_php_vers%-%pfb_cpp_vers%-nts.dll
 
 exit /B 0
 
 :error
-    call :log "PHP %pfb_php_vers% build FAILED"
+    call :log "%pfb_php_tag% build FAILED"
 
 exit /B 1

--- a/build_scripts/php-fb-config.bat
+++ b/build_scripts/php-fb-config.bat
@@ -14,5 +14,5 @@ set PFB_VERS=3.0.1-%GIT_HASH%
 set PFB_OUTPUT_DIR=D:\php-firebird\releases\
 
 @REM FB 32-bit and 64-bit libraries
-set FB32_DIR=C:\Program Files\Firebird\Firebird_5_0-x86
-set FB64_DIR=C:\Program Files\Firebird\Firebird_5_0
+set PFB_FB32_DIR=C:\Program Files\Firebird\Firebird_5_0-x86
+set PFB_FB64_DIR=C:\Program Files\Firebird\Firebird_5_0

--- a/build_scripts/php-fb-sdk-build.bat
+++ b/build_scripts/php-fb-sdk-build.bat
@@ -3,13 +3,13 @@
 @REM Must be called under phpsdk-<php_vers>-<arch>.bat
 @REM
 @REM Calling script should set variables:
-@REM <FB32_DIR> <FB64_DIR> <PFB_SOURCE_DIR> <pfb_php_vers> [pfb_nts] [pfb_x86]
+@REM <PFB_FB32_DIR> <PFB_FB64_DIR> <PFB_SOURCE_DIR> <pfb_php_vers> [pfb_ts] [pfb_arch]
 @REM
 @REM set pfb_php_vers=7.4
-@REM set pfb_nts=1 if nts expected, 0 if ts
-@REM set pfb_x86=1 if linking to x86 fbclient, o if x64
+@REM set pfb_ts=1 if thread safety enabled, 0 if not
+@REM set pfb_arch=x86 to build agains 32-bit, otherwise 64-bit
 @REM
-@REM <FB32_DIR> <FB64_DIR> <PFB_SOURCE_DIR> all set in php-fb-config.bat
+@REM <PFB_FB32_DIR> <PFB_FB64_DIR> <PFB_SOURCE_DIR> all set in php-fb-config.bat
 @REM
 
 goto :MAIN
@@ -25,14 +25,14 @@ goto :MAIN
 exit /B
 
 :MAIN
-    if [%pfb_php_vers%] == [] (
+    if "%pfb_php_vers%" == "" (
         echo pfb_php_vers varible not set
         exit 1
     )
 
     set build_msg=Building PHP-%pfb_php_vers%
 
-    if "%pfb_nts%" gtr "0"  (
+    if "%pfb_ts%" gtr "0" (
         set build_msg=%build_msg% non-TS
         set extra_args=--disable-zts
     ) else (
@@ -40,11 +40,11 @@ exit /B
         set extra_args=
     )
 
-    if "%pfb_x86%" gtr "0"  (
-        set with_interbase="shared,%FB32_DIR%"
+    if "%pfb_arch%" == "x86" (
+        set with_interbase="shared,%PFB_FB32_DIR%"
         set build_msg=%build_msg% x86
     ) else (
-        set with_interbase="shared,%FB64_DIR%"
+        set with_interbase="shared,%PFB_FB64_DIR%"
         set build_msg=%build_msg% x86_64
     )
 

--- a/build_scripts/php-fb-sdk-init.bat
+++ b/build_scripts/php-fb-sdk-init.bat
@@ -2,24 +2,23 @@
 @REM
 @REM Must be called under phpsdk-<php_vers>-<arch>.bat
 @REM
-@REM Calling script should set variables: <pfb_php_vers>
+@REM Calling script should set variables: <pfb_php_vers> <pfb_php_tag>
 @REM
-@REM set pfb_php_vers=7.4
+@REM Example: pfb_php_tag=7.4.13
+@REM Example: pfb_php_vers=7.4
 
-if [%pfb_php_vers%] == [] (
+if "%pfb_php_vers%" == "" (
     echo pfb_php_vers varible not set
     exit 1
 )
 
-@REM Handle current master branch
-if "%pfb_php_vers%" == "master" (
-    set pfb_git_args=
-) else (
-    set pfb_git_args=--branch PHP-%pfb_php_vers%
+if "%pfb_php_tag%" == "" (
+    echo pfb_php_tag varible not set
+    exit 1
 )
 
 call phpsdk_buildtree php%pfb_php_vers%
-git clone --depth 1 %pfb_git_args% https://github.com/php/php-src.git
+git clone --depth 1 --branch %pfb_php_tag% https://github.com/php/php-src.git
 cd php-src
 
 @REM Remove built-in extension

--- a/ibase_service.c
+++ b/ibase_service.c
@@ -210,20 +210,21 @@ PHP_FUNCTION(ibase_delete_user)
 }
 /* }}} */
 
-/* {{{ proto resource ibase_service_attach(string host, string dba_username, string dba_password)
+/* {{{ proto resource ibase_service_attach([string host [, string dba_username [, string dba_password]]])
    Connect to the service manager */
 PHP_FUNCTION(ibase_service_attach)
 {
 	size_t hlen = 0, ulen = 0, plen = 0;
 	ibase_service *svm;
-	char buf[350], *host, *user, *pass;
+	char *host = NULL, *user = NULL, *pass = NULL;
+	char buf[350];
 	char loc[128] = "service_mgr";
 	isc_svc_handle handle = 0;
 	unsigned short p = 0;
 
 	RESET_ERRMSG;
 
-	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "|sss",
+	if (SUCCESS != zend_parse_parameters(ZEND_NUM_ARGS(), "|s!s!s!",
 			&host, &hlen, &user, &ulen, &pass, &plen)) {
 
 		RETURN_FALSE;
@@ -251,14 +252,14 @@ PHP_FUNCTION(ibase_service_attach)
 	if(ulen > 0){
 		buf[p++] = isc_spb_user_name;
 		buf[p++] = (char)ulen;
-		memcpy(&buf[p], &user, ulen);
+		memcpy(&buf[p], user, ulen);
 		p += ulen;
 	}
 
 	if(plen > 0){
 		buf[p++] = isc_spb_password;
 		buf[p++] = (char)plen;
-		memcpy(&buf[p], &pass, plen);
+		memcpy(&buf[p], pass, plen);
 		p += plen;
 	}
 
@@ -274,8 +275,8 @@ PHP_FUNCTION(ibase_service_attach)
 
 	svm = (ibase_service*)emalloc(sizeof(ibase_service));
 	svm->handle = handle;
-	svm->hostname = estrdup(host);
-	svm->username = estrdup(user);
+	svm->hostname = hlen > 0 ? estrdup(host) : NULL;
+	svm->username = ulen > 0 ? estrdup(user) : NULL;
 
 	RETVAL_RES(zend_register_resource(svm, le_service));
 	Z_TRY_ADDREF_P(return_value);


### PR DESCRIPTION
Updated windows build scripts so you can run them directly from php-sdk, without copying
```
c:\php-sdk\
<path_to>\php-firebird\build_scripts\php-fb-build-all.bat 
```

Added some sanity checks too.